### PR TITLE
fix: improve notion sync error handling

### DIFF
--- a/.github/scripts/sync-to-notion.js
+++ b/.github/scripts/sync-to-notion.js
@@ -166,6 +166,7 @@ async function updateNotionPage(pageId, title, blocks) {
     console.log(`Notionページ "${title}" (${pageId}) を更新しました。`);
   } catch (error) {
     console.error(`Notionページ "${title}" (${pageId}) の更新に失敗しました:`, error);
+    throw new Error(`Notionページ "${title}" (${pageId}) の更新に失敗しました: ${error.message}`); // エラーを再スローしてmain関数でキャッチする
   }
 }
 


### PR DESCRIPTION
Catch Notion API errors and exit the process with an error code to ensure GitHub Actions fails correctly.\n\nCloses: #1