### PR TITLE
chore: Configure workflow trigger for main branch

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'articles/**/*.md'
-      - 'books/**/*.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
GitHub Actions の Notion Sync ワークフローのトリガーを、`main` ブランチへの push (マージを含む) に変更しました。

これにより、`paths` フィルターが削除され、`main` ブランチへのすべての変更でワークフローが実行されるようになります。

Closes #3