### PR TITLE
feat: add markdown to notion conversion and upload scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 .vscode
 .env
+output.json

--- a/articles/23c6825ac0617b.md
+++ b/articles/23c6825ac0617b.md
@@ -1,9 +1,13 @@
 ---
-title: "「SNSのQRコード全部入り名刺」の作成を楽する話"
-emoji: "🌟"
-type: "idea" # tech: 技術記事 / idea: アイデア
-topics: [名刺, QRコード, SNS]
+title: 「SNSのQRコード全部入り名刺」の作成を楽する話
+emoji: "\U0001F31F"
+type: idea
+topics:
+  - 名刺
+  - QRコード
+  - SNS
 published: true
+notionPageId: 1c8e310e-775f-81c4-ae10-ccb0ba50ff8c
 ---
 
 ## 利用するSNSが多すぎんねん

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "zenn-docs",
       "dependencies": {
         "@notionhq/client": "^2.3.0",
+        "@tryfabric/martian": "^1.2.4",
         "dotenv": "^16.4.7",
         "gray-matter": "^4.0.3",
         "zenn-cli": "^0.1.158",
@@ -18,17 +19,37 @@
   "packages": {
     "@notionhq/client": ["@notionhq/client@2.3.0", "", { "dependencies": { "@types/node-fetch": "^2.5.10", "node-fetch": "^2.6.1" } }, "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw=="],
 
+    "@tryfabric/martian": ["@tryfabric/martian@1.2.4", "", { "dependencies": { "@notionhq/client": "^1.0.4", "remark-gfm": "^1.0.0", "remark-math": "^4.0.0", "remark-parse": "^9.0.0", "unified": "^9.2.1" } }, "sha512-g7SP7beaxrjxLnW//vskra07a1jsJowqp07KMouxh4gCwaF+ItHbRZN8O+1dhJivBi3VdasT71BPyk+8wzEreQ=="],
+
+    "@types/mdast": ["@types/mdast@3.0.15", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="],
+
     "@types/node": ["@types/node@22.13.14", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.12", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA=="],
+
+    "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "bail": ["bail@1.0.5", "", {}, "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
+    "ccount": ["ccount@1.1.0", "", {}, "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="],
+
+    "character-entities": ["character-entities@1.2.4", "", {}, "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="],
+
+    "character-entities-legacy": ["character-entities-legacy@1.1.4", "", {}, "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="],
+
+    "character-reference-invalid": ["character-reference-invalid@1.1.4", "", {}, "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -44,7 +65,11 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
@@ -66,23 +91,89 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "is-alphabetical": ["is-alphabetical@1.0.4", "", {}, "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="],
+
+    "is-alphanumerical": ["is-alphanumerical@1.0.4", "", { "dependencies": { "is-alphabetical": "^1.0.0", "is-decimal": "^1.0.0" } }, "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A=="],
+
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
+    "is-decimal": ["is-decimal@1.0.4", "", {}, "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="],
+
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
+    "is-hexadecimal": ["is-hexadecimal@1.0.4", "", {}, "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="],
+
+    "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
 
     "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": "bin/js-yaml.js" }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
+    "katex": ["katex@0.12.0", "", { "dependencies": { "commander": "^2.19.0" }, "bin": { "katex": "cli.js" } }, "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg=="],
+
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
+    "longest-streak": ["longest-streak@2.0.4", "", {}, "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="],
+
+    "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@1.1.1", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "unist-util-is": "^4.0.0", "unist-util-visit-parents": "^3.0.0" } }, "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@0.8.5", "", { "dependencies": { "@types/mdast": "^3.0.0", "mdast-util-to-string": "^2.0.0", "micromark": "~2.11.0", "parse-entities": "^2.0.0", "unist-util-stringify-position": "^2.0.0" } }, "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@0.1.2", "", { "dependencies": { "mdast-util-gfm-autolink-literal": "^0.1.0", "mdast-util-gfm-strikethrough": "^0.2.0", "mdast-util-gfm-table": "^0.1.0", "mdast-util-gfm-task-list-item": "^0.1.0", "mdast-util-to-markdown": "^0.6.1" } }, "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@0.1.3", "", { "dependencies": { "ccount": "^1.0.0", "mdast-util-find-and-replace": "^1.1.0", "micromark": "^2.11.3" } }, "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@0.2.3", "", { "dependencies": { "mdast-util-to-markdown": "^0.6.0" } }, "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@0.1.6", "", { "dependencies": { "markdown-table": "^2.0.0", "mdast-util-to-markdown": "~0.6.0" } }, "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@0.1.6", "", { "dependencies": { "mdast-util-to-markdown": "~0.6.0" } }, "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A=="],
+
+    "mdast-util-math": ["mdast-util-math@0.1.2", "", { "dependencies": { "longest-streak": "^2.0.0", "mdast-util-to-markdown": "^0.6.0", "repeat-string": "^1.0.0" } }, "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@0.6.5", "", { "dependencies": { "@types/unist": "^2.0.0", "longest-streak": "^2.0.0", "mdast-util-to-string": "^2.0.0", "parse-entities": "^2.0.0", "repeat-string": "^1.0.0", "zwitch": "^1.0.0" } }, "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@2.0.0", "", {}, "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="],
+
+    "micromark": ["micromark@2.11.4", "", { "dependencies": { "debug": "^4.0.0", "parse-entities": "^2.0.0" } }, "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@0.3.3", "", { "dependencies": { "micromark": "~2.11.0", "micromark-extension-gfm-autolink-literal": "~0.5.0", "micromark-extension-gfm-strikethrough": "~0.6.5", "micromark-extension-gfm-table": "~0.4.0", "micromark-extension-gfm-tagfilter": "~0.3.0", "micromark-extension-gfm-task-list-item": "~0.3.0" } }, "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@0.5.7", "", { "dependencies": { "micromark": "~2.11.3" } }, "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@0.6.5", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@0.4.3", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@0.3.0", "", {}, "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@0.3.3", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ=="],
+
+    "micromark-extension-math": ["micromark-extension-math@0.1.2", "", { "dependencies": { "katex": "^0.12.0", "micromark": "~2.11.0" } }, "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "parse-entities": ["parse-entities@2.0.0", "", { "dependencies": { "character-entities": "^1.0.0", "character-entities-legacy": "^1.0.0", "character-reference-invalid": "^1.0.0", "is-alphanumerical": "^1.0.0", "is-decimal": "^1.0.0", "is-hexadecimal": "^1.0.0" } }, "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ=="],
 
     "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
 
     "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.6.11", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-import-sort": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-style-order": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-import-sort", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-style-order", "prettier-plugin-svelte"] }, "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA=="],
+
+    "remark-gfm": ["remark-gfm@1.0.0", "", { "dependencies": { "mdast-util-gfm": "^0.1.0", "micromark-extension-gfm": "^0.3.0" } }, "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA=="],
+
+    "remark-math": ["remark-math@4.0.0", "", { "dependencies": { "mdast-util-math": "^0.1.0", "micromark-extension-math": "^0.1.0" } }, "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw=="],
+
+    "remark-parse": ["remark-parse@9.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^0.8.0" } }, "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw=="],
+
+    "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
@@ -92,12 +183,30 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "trough": ["trough@1.0.5", "", {}, "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="],
+
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
+    "unified": ["unified@9.2.2", "", { "dependencies": { "bail": "^1.0.0", "extend": "^3.0.0", "is-buffer": "^2.0.0", "is-plain-obj": "^2.0.0", "trough": "^1.0.0", "vfile": "^4.0.0" } }, "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ=="],
+
+    "unist-util-is": ["unist-util-is@4.1.0", "", {}, "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@2.0.3", "", { "dependencies": { "@types/unist": "^2.0.2" } }, "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@3.1.1", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^4.0.0" } }, "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg=="],
+
+    "vfile": ["vfile@4.2.1", "", { "dependencies": { "@types/unist": "^2.0.0", "is-buffer": "^2.0.0", "unist-util-stringify-position": "^2.0.0", "vfile-message": "^2.0.0" } }, "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA=="],
+
+    "vfile-message": ["vfile-message@2.0.4", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-stringify-position": "^2.0.0" } }, "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "zenn-cli": ["zenn-cli@0.1.158", "", { "bin": { "zenn": "dist/server/zenn.js" } }, "sha512-bvQ96fK+9qw+SKxEmncg/rYU+1u0V6Bh+HuV8By+u4L+VZt/jn9hFyL+KWj/2ncSBDtcEBo6XLsCdNLxlUo+RA=="],
+
+    "zwitch": ["zwitch@1.0.5", "", {}, "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="],
+
+    "@tryfabric/martian/@notionhq/client": ["@notionhq/client@1.0.4", "", { "dependencies": { "@types/node-fetch": "^2.5.10", "node-fetch": "^2.6.1" } }, "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "@notionhq/client": "^2.3.0",
+    "@tryfabric/martian": "^1.2.4",
     "dotenv": "^16.4.7",
     "gray-matter": "^4.0.3",
     "zenn-cli": "^0.1.158"

--- a/scripts/convert-md-to-notion.js
+++ b/scripts/convert-md-to-notion.js
@@ -1,0 +1,27 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { markdownToBlocks } from '@tryfabric/martian';
+import matter from 'gray-matter';
+
+const convertMarkdownToNotionBlocks = async (filePath) => {
+  const outputFilePath = 'output.json'; // 出力ファイル名
+  try {
+    const markdownContent = await fs.readFile(filePath, 'utf-8');
+    // Frontmatter をパース
+    const { content: markdownBody, data: frontmatter } = matter(markdownContent);
+    console.log('--- Frontmatter ---');
+    console.log(frontmatter);
+    console.log('--- Notion Blocks ---');
+    const notionBlocks = markdownToBlocks(markdownBody);
+    // 結果をファイルに出力
+    await fs.writeFile(outputFilePath, JSON.stringify(notionBlocks, null, 2));
+    console.log(`Conversion successful. Output saved to ${outputFilePath}`);
+  } catch (error) {
+    console.error(`Error converting markdown file ${filePath}:`, error);
+  }
+};
+
+// サンプルファイルのパスを指定
+const sampleFilePath = path.join('articles', '2b6b1d3bd81334.md');
+
+convertMarkdownToNotionBlocks(sampleFilePath);

--- a/scripts/update-database-schema.js
+++ b/scripts/update-database-schema.js
@@ -1,0 +1,65 @@
+import { Client } from '@notionhq/client';
+import dotenv from 'dotenv';
+
+// .env ファイルから環境変数を読み込む
+dotenv.config();
+
+const notion = new Client({ auth: process.env.NOTION_API_KEY });
+const databaseId = process.env.NOTION_DATABASE_ID;
+
+if (!process.env.NOTION_API_KEY || !databaseId) {
+  console.error('Error: NOTION_API_KEY and NOTION_DATABASE_ID must be set in .env file.');
+  process.exit(1);
+}
+
+// 追加したいプロパティの定義 (エラーメッセージに基づき、前回指定された名前を使用)
+const propertiesToAdd = {
+  Tags: { multi_select: {} },
+  Published: { checkbox: {} },
+  Slug: { rich_text: {} },
+  Icon: { rich_text: {} }
+};
+
+const updateDatabaseSchema = async () => {
+  try {
+    // 1. 現在のデータベース定義を取得
+    console.log('Retrieving current database schema...');
+    const currentDatabase = await notion.databases.retrieve({ database_id: databaseId });
+    const currentProperties = currentDatabase.properties;
+    console.log('Current properties retrieved.');
+
+    // 2. 新しいプロパティ定義を追加 (既存のものはそのまま保持)
+    const updatedProperties = { ...currentProperties };
+    let propertiesAddedCount = 0;
+    for (const propertyName in propertiesToAdd) {
+      if (!currentProperties[propertyName]) { // まだ存在しないプロパティのみ追加
+        updatedProperties[propertyName] = propertiesToAdd[propertyName];
+        propertiesAddedCount++;
+        console.log(`Adding property: ${propertyName}`);
+      } else {
+        console.log(`Property "${propertyName}" already exists. Skipping.`);
+      }
+    }
+
+    if (propertiesAddedCount === 0) {
+        console.log('No new properties to add. Schema is up-to-date with required properties.');
+        return;
+    }
+
+    // 3. データベースを更新
+    console.log('Updating database schema...');
+    await notion.databases.update({
+      database_id: databaseId,
+      properties: updatedProperties,
+    });
+    console.log('Database schema updated successfully!');
+
+  } catch (error) {
+    console.error('Error updating database schema:', error);
+    if (error.body) {
+      console.error('Notion API Error Body:', error.body);
+    }
+  }
+};
+
+updateDatabaseSchema();

--- a/scripts/upload-to-notion.js
+++ b/scripts/upload-to-notion.js
@@ -1,0 +1,235 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Client } from '@notionhq/client';
+import { markdownToBlocks } from '@tryfabric/martian';
+import matter from 'gray-matter';
+import dotenv from 'dotenv';
+
+// .env ファイルから環境変数を読み込む
+dotenv.config();
+
+const notion = new Client({ auth: process.env.NOTION_API_KEY });
+const databaseId = process.env.NOTION_DATABASE_ID;
+
+if (!process.env.NOTION_API_KEY || !databaseId) {
+  console.error('Error: NOTION_API_KEY and NOTION_DATABASE_ID must be set in .env file.');
+  process.exit(1);
+}
+
+// Notion ページのプロパティを Frontmatter から作成する関数
+const createPageProperties = (frontmatter, filePath) => { // filePath を引数に追加
+  const properties = {
+    // タイトル (必須)
+    Name: { // Notion データベースのタイトルプロパティ名に合わせてください
+      title: [
+        {
+          text: {
+            content: frontmatter.title || 'Untitled',
+          },
+        },
+      ],
+    },
+    // トピック (マルチセレクトプロパティの例)
+    Tags: { // Notion データベースのプロパティ名に合わせてください
+      multi_select: (frontmatter.topics || []).map(topic => ({ name: topic })),
+    },
+    // 公開状態 (チェックボックスプロパティの例)
+    Published: { // Notion データベースのプロパティ名に合わせてください
+      checkbox: frontmatter.published || false,
+    },
+    // Zenn Slug (テキストプロパティの例)
+    Slug: { // Notion データベースのプロパティ名に合わせてください
+      rich_text: [
+        {
+          text: {
+            content: path.basename(filePath, '.md'), // ファイル名を Slug とする例
+          },
+        },
+      ],
+    },
+    // 絵文字 (テキストプロパティの例 - Notion ではアイコンとして設定可能)
+    Icon: { // Notion データベースのプロパティ名に合わせてください
+        rich_text: [
+            {
+                text: {
+                    content: frontmatter.emoji || '📄'
+                }
+            }
+        ]
+    }
+    // 必要に応じて他のプロパティを追加
+  };
+  return properties;
+};
+
+// 既存の Notion ページの全ブロックを削除する関数
+const clearPageBlocks = async (pageId) => {
+  let hasMore = true;
+  let startCursor = undefined;
+  const blocksToDelete = [];
+
+  while (hasMore) {
+    const response = await notion.blocks.children.list({
+      block_id: pageId,
+      start_cursor: startCursor,
+    });
+    blocksToDelete.push(...response.results);
+    hasMore = response.has_more;
+    startCursor = response.next_cursor;
+  }
+
+  // Notion API は一度に削除できるブロック数に制限があるため、ループで削除
+  // 削除は逆順で行うことで、子ブロックを持つブロックの削除問題を回避しやすくする
+  for (const block of blocksToDelete.reverse()) {
+    try {
+      await notion.blocks.delete({ block_id: block.id });
+    } catch (error) {
+      // 子を持つブロックなどを削除しようとするとエラーになることがあるため警告に留める
+      console.warn(`Could not delete block ${block.id} (might have children or be unsupported):`, error.message);
+    }
+  }
+};
+
+
+// Notion ページにブロックを追加する関数 (100件ずつ分割)
+const appendBlocksToPage = async (pageId, blocks) => {
+  const chunkSize = 100; // Notion API の制限
+  for (let i = 0; i < blocks.length; i += chunkSize) {
+    const chunk = blocks.slice(i, i + chunkSize);
+    try {
+      await notion.blocks.children.append({
+        block_id: pageId,
+        children: chunk,
+      });
+    } catch (error) {
+      console.error(`Error appending blocks chunk ${Math.floor(i / chunkSize) + 1}:`, error);
+      // エラーが発生したブロックの内容をログに出力（デバッグ用）
+      console.error('Failed blocks chunk:', JSON.stringify(chunk, null, 2));
+      // エラーの詳細を出力
+      if (error.body) {
+        console.error('Notion API Error Body:', error.body);
+      }
+      throw error; // エラーを再スローして処理を中断
+    }
+  }
+};
+
+// Markdown ファイルを Notion にアップロードするメイン関数
+const uploadMarkdownToNotion = async (filePath) => {
+  console.log(`Processing file: ${filePath}`);
+  try {
+    const markdownContent = await fs.readFile(filePath, 'utf-8');
+    const { content: markdownBody, data: frontmatter } = matter(markdownContent);
+
+    if (!frontmatter.title) {
+      console.warn(`Skipping ${filePath}: Title is missing in frontmatter.`);
+      return;
+    }
+
+    const notionBlocks = markdownToBlocks(markdownBody);
+    const pageProperties = createPageProperties(frontmatter, filePath); // filePath を渡す
+
+    let pageId = frontmatter.notionPageId;
+
+    if (pageId) {
+      // --- 既存ページの更新 ---
+      console.log(`Updating existing Notion page: ${pageId}`);
+      try {
+        // 1. ページのプロパティを更新
+        await notion.pages.update({
+          page_id: pageId,
+          properties: pageProperties,
+          // アイコンも更新する場合
+          icon: frontmatter.emoji ? { type: 'emoji', emoji: frontmatter.emoji } : undefined,
+          archived: false // アーカイブされていたら解除
+        });
+        console.log('Page properties updated.');
+
+        // 2. 既存のブロックをクリア
+        console.log('Clearing existing blocks...');
+        await clearPageBlocks(pageId);
+        console.log('Existing blocks cleared.');
+
+        // 3. 新しいブロックを追加
+        console.log('Appending new blocks...');
+        await appendBlocksToPage(pageId, notionBlocks);
+        console.log('New blocks appended.');
+
+        console.log(`Successfully updated page: https://www.notion.so/${pageId.replace(/-/g, '')}`);
+
+      } catch (error) {
+        if (error.code === 'object_not_found') {
+          console.warn(`Page ${pageId} not found or archived. Creating a new page instead.`);
+          pageId = null; // ページが見つからない場合は新規作成フローへ
+        } else {
+          console.error(`Error updating page ${pageId}:`, error);
+           if (error.body) {
+             console.error('Notion API Error Body:', error.body);
+           }
+          return; // 更新エラーの場合は処理中断
+        }
+      }
+    }
+
+    if (!pageId) {
+      // --- 新規ページの作成 ---
+      console.log('Creating new Notion page...');
+      try {
+        const response = await notion.pages.create({
+          parent: { database_id: databaseId },
+          properties: pageProperties,
+          // アイコンを設定する場合
+          icon: frontmatter.emoji ? { type: 'emoji', emoji: frontmatter.emoji } : undefined,
+          // children は append で追加
+        });
+        pageId = response.id;
+        console.log(`New page created with ID: ${pageId}`);
+
+        // 新しく作成したページにブロックを追加
+        console.log('Appending blocks to the new page...');
+        await appendBlocksToPage(pageId, notionBlocks);
+        console.log('Blocks appended to the new page.');
+
+        // Markdown ファイルに notionPageId を追記
+        const newFrontmatter = { ...frontmatter, notionPageId: pageId };
+        // YAML Frontmatter の整形
+        const newMarkdownContent = matter.stringify(markdownBody, newFrontmatter, {
+            lineWidth: -1, // 自動改行しない
+            noRefs: true, // YAML参照を使わない
+            sortKeys: false // キーをソートしない (元の順序を維持)
+        });
+        await fs.writeFile(filePath, newMarkdownContent, 'utf-8');
+        console.log(`Added notionPageId to ${filePath}`);
+
+        console.log(`Successfully created page: https://www.notion.so/${pageId.replace(/-/g, '')}`);
+
+      } catch (error) {
+        console.error('Error creating page:', error);
+        // エラーの詳細を出力
+        if (error.body) {
+            console.error('Notion API Error Body:', error.body);
+        }
+      }
+    }
+
+  } catch (error) {
+    console.error(`Error processing file ${filePath}:`, error);
+  }
+};
+
+// --- メイン処理 ---
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error('Usage: bun scripts/upload-to-notion.js <markdown_file_path>');
+  process.exit(1);
+}
+
+const filePath = args[0];
+
+// ファイル存在確認
+fs.access(filePath)
+  .then(() => uploadMarkdownToNotion(filePath))
+  .catch((err) => {
+    console.error(`Error: File not found or inaccessible - ${filePath}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
*   Markdown ファイルを Notion ページに変換・アップロードする機能を追加しました。
*   `@tryfabric/martian`, `gray-matter`, `@notionhq/client`, `dotenv` ライブラリを導入。
*   以下のスクリプトを作成・修正:
    *   `scripts/convert-md-to-notion.js`: Markdown を Notion ブロックに変換するサンプルスクリプト。
    *   `scripts/upload-to-notion.js`: 指定された Markdown ファイルを Notion にアップロードするスクリプト。Frontmatter を読み取り、Notion ページのプロパティを設定し、既存ページの場合は更新、新規の場合は作成します。
    *   `scripts/update-database-schema.js`: Notion データベースに不足しているプロパティを追加するスクリプト。
*   `.gitignore` に `output.json` を追加。
*   Notion へのアップロード時に Markdown ファイルに `notionPageId` を追記するように修正。
*   Notion API エラー（アーカイブ済みブロック、競合）に対応するため、`clearPageBlocks` 関数のエラーハンドリングを改善し、API 負荷軽減のための待機処理を追加。
*   Closes #5